### PR TITLE
[+] fix internal representations

### DIFF
--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -45,7 +45,23 @@ class Interpreter {
 
     let envs = opts.environments || {};
     let env = envs[opts.environment] || {objects: {}};
-    this.importable = env.objects;
+    this.importable = {};
+    _.each(env.objects, ( value, key ) => {
+      var type;
+      switch (typeof value) {
+        case 'string':
+          type = TYPE.STRING;
+          break;
+        case 'number':
+          type = TYPE.NUMBER;
+        case 'object': // asume contract object
+          type = new TYPE.OBJECT (type.class)
+        default:
+          throw new Error('unknown type in evironment object: '+obj);
+          
+      }
+      this.importable[key] = new Expr(value, [], type);
+    });
 
     // todo - process somehow
     this.classes = opts.classes;
@@ -77,7 +93,7 @@ class Interpreter {
       } else if (ast.type === TYPE.SEQ) { // SEQUENCE
         return ast.value.map(interpret);
       } else if (ast.type.atom) { // AST - ATOM
-        return ast.value;
+        return ast;
       } else { // AST - FUNCTION
         return ast.value.apply(self, ast.args.map(interpret).concat([ast]));
       }
@@ -107,12 +123,7 @@ class Interpreter {
   }
 
   log_args (args) {
-    var self = this;
-    args = this.serialize(args);
-
-    return args.map(atom => {
-      self.log(atom);
-    });
+    return this.log(this.serializeAtom(args));
   }
 
   assign (key, value) {
@@ -128,18 +139,20 @@ class Interpreter {
   serialize (args) {
     var self = this;
     return args.map(atom => {
-      // TODO - test with atoms
-      //
-      // reference
-      if (typeof atom === 'string') {
-        if (typeof self.local[atom].value === 'undefined') {
-          return self.local[atom];
-        }
-        return self.local[atom].value;
-      }
-      // atom
-      return atom.value;
+      return self.serializeAtom(atom);
     });
+  }
+  
+  serializeAtom (atom) {
+    if (typeof atom === 'string') {
+      console.log(this.local[atom], atom);
+      if (typeof this.local[atom].value === 'undefined') {
+        return this.local[atom];
+      }
+      return this.local[atom].value;
+    }
+    // atom
+    return atom.value;
   }
 
   export (key) {
@@ -173,7 +186,7 @@ class Interpreter {
         className,
         abi: this.classes[className].interface,
         bytecode: this.classes[className].bytecode,
-        args: args,
+        args: this.serialize(args),
         value: txOptions.value,
         gas: txOptions.gas
       });
@@ -210,7 +223,7 @@ class Interpreter {
       })[0];
       if (!functionInterface) throw new Error(`${fName} is not a valid function of class ${className}`);
       var constant = functionInterface.constant;
-      var args = _args;
+      var args = this.serialize(_args);
       var result = this.web3Interface.call({args, fName, constant, abi, address});
       // REPORT
       this.log(`CALLED: ${className}("${ contract.value }").${ fName }(${args.join(',')})\n`);

--- a/lib/interpreter.js
+++ b/lib/interpreter.js
@@ -46,7 +46,7 @@ class Interpreter {
     let envs = opts.environments || {};
     let env = envs[opts.environment] || {objects: {}};
     this.importable = {};
-    _.each(env.objects, ( value, key ) => {
+    _.each(env.objects, (value, key) => {
       var type;
       switch (typeof value) {
         case 'string':
@@ -54,11 +54,12 @@ class Interpreter {
           break;
         case 'number':
           type = TYPE.NUMBER;
+          break;
         case 'object': // asume contract object
-          type = new TYPE.OBJECT (type.class)
+          type = new TYPE.OBJECT(type.class);
+          break;
         default:
-          throw new Error('unknown type in evironment object: '+obj);
-          
+          throw new Error('unknown type in evironment object: ' + value);
       }
       this.importable[key] = new Expr(value, [], type);
     });
@@ -142,7 +143,7 @@ class Interpreter {
       return self.serializeAtom(atom);
     });
   }
-  
+
   serializeAtom (atom) {
     if (typeof atom === 'string') {
       console.log(this.local[atom], atom);

--- a/specs/dsl.y
+++ b/specs/dsl.y
@@ -54,7 +54,7 @@ DECLARATION: VAR SYMBOL "=" TERM
            ;
 
 LOG_STATEMENT: LOG TERM
-               { $$ = new yy.i.Expr( yy.i.log, [$TERM], yy.i.TYPE.LOG ); }
+               { $$ = new yy.i.Expr( yy.i.log_args, [$TERM], yy.i.TYPE.LOG ); }
                ;
 
 TERM: DEPLOYMENT

--- a/test/dsl_test.js
+++ b/test/dsl_test.js
@@ -106,7 +106,7 @@ describe('DSL', function () {
       done();
     });
   });
-  
+
   it.skip('should pass an object as a deploy argument', function (done) {
     parser.parse('var foo = new Contract()\n var bar = new Contract(foo)', function (err, res) {
       // TODO: test if foo got passed as an correct address

--- a/test/dsl_test.js
+++ b/test/dsl_test.js
@@ -43,7 +43,7 @@ describe('DSL', function () {
     parser.parse('var foo = "bar"', function (err, res) {
       if (err) throw err;
       assert(parser.interpreter.success);
-      assert(parser.interpreter.local.foo === 'bar');
+      assert(parser.interpreter.local.foo.value === 'bar');
       done();
     });
   });
@@ -52,7 +52,7 @@ describe('DSL', function () {
     parser.parse('var foo = 42', function (err, res) {
       if (err) throw err;
       assert(parser.interpreter.success);
-      assert(parser.interpreter.local.foo === 42);
+      assert(parser.interpreter.local.foo.value === 42);
       done();
     });
   });
@@ -61,11 +61,11 @@ describe('DSL', function () {
     parser.parse('var foo = 42', function (err, res) {
       if (err) throw err;
       assert.ok(parser.interpreter.success);
-      assert(parser.interpreter.local.foo === 42);
+      assert(parser.interpreter.local.foo.value === 42);
       parser.parse('var foo = 17', function (err, res) {
         if (err) throw err;
         assert.notOk(parser.interpreter.success);
-        assert(parser.interpreter.local.foo === 42);
+        assert(parser.interpreter.local.foo.value === 42);
         done();
       });
     });
@@ -84,7 +84,7 @@ describe('DSL', function () {
     parser.parse('var foo = 17\nexport foo', function (err, res) {
       if (err) throw err;
       assert.ok(parser.interpreter.success);
-      assert(parser.interpreter.global.foo === 17);
+      assert(parser.interpreter.global.foo.value === 17);
       done();
     });
   });
@@ -93,7 +93,7 @@ describe('DSL', function () {
     parser.parse('var foo = 17\nexport foo\nvar foo = 42\nexport foo', function (err, res) {
       if (err) throw err;
       assert.notOk(parser.interpreter.success);
-      assert(parser.interpreter.global.foo === 17);
+      assert(parser.interpreter.global.foo.value === 17);
       done();
     });
   });
@@ -103,6 +103,15 @@ describe('DSL', function () {
       if (err) throw err;
       assert.ok(parser.interpreter.success);
       assert(parser.interpreter.local.foo.value.length === 42);
+      done();
+    });
+  });
+  
+  it.skip('should pass an object as a deploy argument', function (done) {
+    parser.parse('var foo = new Contract()\n var bar = new Contract(foo)', function (err, res) {
+      // TODO: test if foo got passed as an correct address
+      if (err) throw err;
+      assert.ok(parser.interpreter.success);
       done();
     });
   });


### PR DESCRIPTION
There was a problem with passing objects as deploy arguments: they got passed as object-expressions and not as addresses. This fix this issue by holding internal representations always as typed expressions.